### PR TITLE
[BUGFIX] Fix path issue with composer installations

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -10,9 +10,14 @@ use T3G\Elasticorn\Commands\Self\RollbackCommand;
 use T3G\Elasticorn\Commands\Self\UpdateCommand;
 
 // env config
-if (file_exists($basePath . '/.env')) {
-    $dotenv = new Dotenv\Dotenv($basePath);
-    $dotenv->load();
+// Determine the .env file in package directory ($baseBath === __DIR__) and getcwd()
+// this prevent path errors in case of global composer installation and package requirement
+foreach([$basePath . '/.env', getcwd() . '/.env'] as $file) {
+    if (file_exists($file)) {
+        $dotenv = new Dotenv\Dotenv($file);
+        $dotenv->load();
+        break;
+    }
 }
 
 // dependency injection initialization

--- a/elasticorn.php
+++ b/elasticorn.php
@@ -12,5 +12,25 @@ if (method_exists(Phar::class, 'running')) {
     }
 }
 
-require_once __DIR__ . '/vendor/autoload.php';
-require_once __DIR__ . '/bootstrap.php';
+// Determine the autoload.php file this prevent path errors
+// in case of global composer installation and package requirement
+$autoloadFile = 'vendor/autoload.php';
+foreach ([__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php'] as $file) {
+    if (file_exists($file)) {
+        $autoloadFile = $file;
+        break;
+    }
+}
+
+// Determine the bootstrap.php file this prevent path errors
+// in case of global composer installation and package requirement
+$bootstrapFile = 'bootstrap.php';
+foreach ([__DIR__ . '/../../bootstrap.php', __DIR__ . '/../bootstrap.php', __DIR__ . '/bootstrap.php'] as $file) {
+    if (file_exists($file)) {
+        $bootstrapFile = $file;
+        break;
+    }
+}
+
+require_once $autoloadFile;
+require_once $bootstrapFile;


### PR DESCRIPTION
In case of global composer installation or package dependency installation,
the pathes to autoload.php, bootstrap.php and the .env file are broken.
elasticorn shows a Fatal error:
require_once(): Failed opening required 'vendor/autoload.php'

This patch check multiple locations and fix the path issue. The same solution
is used by PHPUnit.